### PR TITLE
Adding alignByte

### DIFF
--- a/BitsQC.hs
+++ b/BitsQC.hs
@@ -271,7 +271,7 @@ prop_composite_case b (W w) = w < 0x8000 ==>
              putWord16be 15 w
       g = do v <- getBool
              case v of
-              True -> getWord16be 15
+              True -> getWord16 15
               False -> do
                 msb <- getWord8 7
                 lsb <- getWord8 8
@@ -395,7 +395,7 @@ type Program = [Primitive]
 instance Arbitrary Primitive where
   arbitrary = do
     let gen c = do
-          let (maxBits, _) = (\w -> (bitSize w, c undefined w)) undefined
+          let (maxBits, _) = (\w -> (finiteBitSize w, c undefined w)) undefined
           bits <- choose (0, maxBits)
           n <- choose (0, fromIntegral (2^bits-1))
           return (c bits n)
@@ -458,9 +458,9 @@ getPrimitive p =
   case p of
     Bool _ -> Bool <$> getBool
     W8 n _ -> W8 n <$> getWord8 n
-    W16 n _ -> W16 n <$> getWord16be n
-    W32 n _ -> W32 n <$> getWord32be n
-    W64 n _ -> W64 n <$> getWord64be n
+    W16 n _ -> W16 n <$> getWord16 n
+    W32 n _ -> W32 n <$> getWord32 n
+    W64 n _ -> W64 n <$> getWord64 n
     BS n _ -> BS n <$> getByteString n
     LBS n _ -> LBS n <$> getLazyByteString n
     IsEmpty -> isEmpty >> return IsEmpty
@@ -474,9 +474,9 @@ verifyProgram totalLength ps0 = go 0 ps0
       case p of
         Bool x -> check x getBool >> go (pos+1) ps
         W8 n x ->  check x (getWord8 n) >> go (pos+n) ps
-        W16 n x -> check x (getWord16be n) >> go (pos+n) ps
-        W32 n x -> check x (getWord32be n) >> go (pos+n) ps
-        W64 n x -> check x (getWord64be n) >> go (pos+n) ps
+        W16 n x -> check x (getWord16 n) >> go (pos+n) ps
+        W32 n x -> check x (getWord32 n) >> go (pos+n) ps
+        W64 n x -> check x (getWord64 n) >> go (pos+n) ps
         BS n x -> check x (getByteString n) >> go (pos+(8*n)) ps
         LBS n x -> check x (getLazyByteString n) >> go (pos+(8*n)) ps
         IsEmpty -> do

--- a/BitsQC.hs
+++ b/BitsQC.hs
@@ -268,7 +268,7 @@ prop_bitreq (W w) = property $
 prop_composite_case :: Bool -> W Word16 -> Property
 prop_composite_case b (W w) = w < 0x8000 ==>
   let p = do putBool b
-             putWord16be 15 w
+             putWord16 15 w
       g = do v <- getBool
              case v of
               True -> getWord16 15
@@ -446,9 +446,9 @@ putPrimitive p =
   case p of
     Bool b -> putBool b
     W8 n x -> putWord8 n x
-    W16 n x -> putWord16be n x
-    W32 n x -> putWord32be n x
-    W64 n x -> putWord64be n x
+    W16 n x -> putWord16 n x
+    W32 n x -> putWord32 n x
+    W64 n x -> putWord64 n x
     BS _ bs -> putByteString bs
     LBS _ lbs -> mapM_ putByteString (L.toChunks lbs)
     IsEmpty -> return ()

--- a/Data/Binary/Bits.hs
+++ b/Data/Binary/Bits.hs
@@ -33,13 +33,13 @@ instance BinaryBit Word8 where
   getBits = getWord8
 
 instance BinaryBit Word16 where
-  putBits = putWord16be
+  putBits = putWord16
   getBits = getWord16
 
 instance BinaryBit Word32 where
-  putBits = putWord32be
+  putBits = putWord32
   getBits = getWord32
 
 instance BinaryBit Word64 where
-  putBits = putWord64be
+  putBits = putWord64
   getBits = getWord64

--- a/Data/Binary/Bits.hs
+++ b/Data/Binary/Bits.hs
@@ -34,12 +34,12 @@ instance BinaryBit Word8 where
 
 instance BinaryBit Word16 where
   putBits = putWord16be
-  getBits = getWord16be
+  getBits = getWord16
 
 instance BinaryBit Word32 where
   putBits = putWord32be
-  getBits = getWord32be
+  getBits = getWord32
 
 instance BinaryBit Word64 where
   putBits = putWord64be
-  getBits = getWord64be
+  getBits = getWord64

--- a/Data/Binary/Bits/BitOrder.hs
+++ b/Data/Binary/Bits/BitOrder.hs
@@ -1,0 +1,28 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Binary.Bits.Get
+-- Copyright   :  (c) Lennart Kolmodin 2010-2011
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  kolmodin@gmail.com
+-- Stability   :  experimental
+-- Portability :  portable (should run where the package binary runs)
+
+module Data.Binary.Bits.BitOrder
+   ( BitOrder(..)
+   )
+where
+
+-- | Bit order
+--
+-- E.g. two words of 5 bits: ABCDE, VWXYZ
+--    - BB: ABCDEVWX YZxxxxxx
+--    - LB: XYZABCDE xxxxxxVW
+--    - BL: EDCBAZYX WVxxxxxx
+--    - LL: XWVEDCBA xxxxxxZY
+data BitOrder
+   = BB  -- ^ Big-endian bytes and bits
+   | LB  -- ^ Little-endian bytes, big-endian bits
+   | BL  -- ^ Big-endian bytes, little-endian bits
+   | LL  -- ^ Little-endian bytes and bits
+   deriving (Show)

--- a/Data/Binary/Bits/BitOrder.hs
+++ b/Data/Binary/Bits/BitOrder.hs
@@ -2,6 +2,7 @@
 -- |
 -- Module      :  Data.Binary.Bits.Get
 -- Copyright   :  (c) Lennart Kolmodin 2010-2011
+--                (c) Sylvain Henry 2015
 -- License     :  BSD3-style (see LICENSE)
 --
 -- Maintainer  :  kolmodin@gmail.com

--- a/Data/Binary/Bits/BitOrder.hs
+++ b/Data/Binary/Bits/BitOrder.hs
@@ -11,6 +11,7 @@
 
 module Data.Binary.Bits.BitOrder
    ( BitOrder(..)
+   , BitOrderable(..)
    )
 where
 
@@ -27,3 +28,20 @@ data BitOrder
    | BL  -- ^ Big-endian bytes, little-endian bits
    | LL  -- ^ Little-endian bytes and bits
    deriving (Show)
+
+
+class Monad m => BitOrderable m where
+   -- | Set the current bit-order
+   setBitOrder :: BitOrder -> m ()
+
+   -- | Retrieve the current bit-order
+   getBitOrder    :: m BitOrder
+
+   -- | Perform the given action with the given bit-order
+   withBitOrder   :: BitOrder -> m a -> m a
+   withBitOrder bo act = do
+      bo' <- getBitOrder
+      setBitOrder bo
+      r <- act
+      setBitOrder bo'
+      return r

--- a/Data/Binary/Bits/Get.hs
+++ b/Data/Binary/Bits/Get.hs
@@ -276,15 +276,8 @@ extract bo bs o n
 readWord :: (Num a, Bits a, FastBits a) => Int -> S -> a
 readWord n (S bs o bo)
    | n == 0    = 0
-   | o+n <= 8  = extract bo (unsafeTake 1 bs) o n
-   | o+n <= 16 = extract bo (unsafeTake 2 bs) o n
-   | o+n <= 24 = extract bo (unsafeTake 3 bs) o n
-   | o+n <= 32 = extract bo (unsafeTake 4 bs) o n
-   | o+n <= 40 = extract bo (unsafeTake 5 bs) o n
-   | o+n <= 48 = extract bo (unsafeTake 6 bs) o n
-   | o+n <= 56 = extract bo (unsafeTake 7 bs) o n
-   | o+n <= 64 = extract bo (unsafeTake 8 bs) o n
-   | otherwise = extract bo (unsafeTake ((o+n+7) `div` 8)  bs) o n
+   | otherwise = extract bo (unsafeTake nbytes bs) o n
+   where nbytes = byte_offset (o+n+7)
 
 -- | Check that the number of bits to read is not greater than the first parameter
 {-# INLINE readWordChecked #-}

--- a/Data/Binary/Bits/Get.hs
+++ b/Data/Binary/Bits/Get.hs
@@ -276,7 +276,10 @@ readWordChecked m n s
 --    LB: NOPQRxxx FGHIJKLM xxxABCDE -> ABCDEFGH IJKLMNOP QRxxxxxx
 readByteString :: Int -> S -> ByteString
 readByteString n (S bs o bo)
-  | o == 0    = unsafeTake n bs
+  | o == 0    = case bo of
+      BB -> unsafeTake n bs
+      LB -> B.reverse (unsafeTake n bs)
+
   | otherwise = unsafePerformIO $ do
       let len = n+1
       ptr <- mallocBytes len

--- a/Data/Binary/Bits/Get.hs
+++ b/Data/Binary/Bits/Get.hs
@@ -55,7 +55,9 @@ module Data.Binary.Bits.Get
             -- $bitget
 
               BitGet
+            , BitOrder(..)
             , runBitGet
+            , selectBitOrder
 
             -- ** Get bytes
             , getBool
@@ -158,32 +160,9 @@ import GHC.Word
 -- @
 
 data S = S {-# UNPACK #-} !ByteString -- Input
-           {-# UNPACK #-} !Int -- Bit offset (0-7)
+           {-# UNPACK #-} !Int        -- Bit offset (0-7)
+                          !BitOrder   -- Bit order
           deriving (Show)
-
--- | A block that will be read with only one boundary check. Needs to know the
--- number of bits in advance.
-data Block a = Block Int (S -> a)
-
-instance Functor Block where
-  fmap f (Block i p) = Block i (\s -> f (p s))
-
-instance Applicative Block where
-  pure a = Block 0 (\_ -> a)
-  (Block i p) <*> (Block j q) = Block (i+j) (\s -> p s $ q (incS i s))
-  (Block i _)  *> (Block j q) = Block (i+j) (q . incS i)
-  (Block i p) <*  (Block j _) = Block (i+j) p
-
--- | Get a block. Will be read with one single boundry check, and
--- therefore requires a statically known number of bits.
--- Build blocks using 'bool', 'word8', 'word16be', 'word32be', 'word64be',
--- 'byteString' and 'Applicative'.
-block :: Block a -> BitGet a
-block (Block i p) = do
-  ensureBits i
-  s <- getState
-  putState $! (incS i s)
-  return $! p s
 
 -- | Compute bit offset (equivalent to x `mod` 8 but faster)
 bit_offset :: Int -> Int
@@ -197,11 +176,15 @@ byte_offset n = n `shiftR` 3
 
 -- | Increment the current bit offset
 incS :: Int -> S -> S
-incS o (S bs n) = S (unsafeDrop d bs) n'
+incS o (S bs n bo) = S (unsafeDrop d bs) n' bo
    where
       !o' = (n+o)
       !d  = byte_offset o'
       !n' = bit_offset o'
+
+-- | Select the bit ordering
+selectBitOrderS :: BitOrder -> S -> S
+selectBitOrderS bo (S bs o _) = S bs o bo
 
 -- | make_mask 3 = 00000111
 make_mask :: (Bits a, Num a) => Int -> a
@@ -218,33 +201,6 @@ mask :: (Bits a, Num a) => Int -> a -> a
 mask n v = v .&. make_mask n
 {-# INLINE mask #-}
 
-class FastBits a where
-   fastShiftR :: a -> Int -> a
-   fastShiftL :: a -> Int -> a
-
-   {-# INLINE fastShift #-}
-   fastShift :: a -> Int -> a
-   fastShift x n
-      | n > 0 = fastShiftL x n
-      | n < 0 = fastShiftR x (negate n)
-      | otherwise = x
-
-instance FastBits Word8 where
-   fastShiftR = shiftr_w8
-   fastShiftL = shiftl_w8
-
-instance FastBits Word16 where
-   fastShiftR = shiftr_w16
-   fastShiftL = shiftl_w16
-
-instance FastBits Word32 where
-   fastShiftR = shiftr_w32
-   fastShiftL = shiftl_w32
-
-instance FastBits Word64 where
-   fastShiftR = shiftr_w64
-   fastShiftL = shiftl_w64
-
 -- | Bit order
 --
 -- E.g. two words of 5 bits: ABCDE, VWXYZ
@@ -252,13 +208,14 @@ instance FastBits Word64 where
 --    - LB: XYZABCDE xxxxxxVW
 --    - BL: EDCBAZYX WVxxxxxx   -- not implemented
 --    - LL: XWVEDCBA xxxxxxZY   -- not implemented
-data BitOrder = BB | LB
+data BitOrder = BB | LB deriving (Show)
 
 
 -- | Read a single bit
-readBool :: BitOrder -> S -> Bool
-readBool BB (S bs n) = testBit (unsafeHead bs) (7-n)
-readBool LB (S bs n) = testBit (unsafeHead bs) n
+readBool :: S -> Bool
+readBool (S bs o bo) = case bo of
+   BB -> testBit (unsafeHead bs) (7-o)
+   LB -> testBit (unsafeHead bs) o
 
 -- | Extract a range of bits from (ws :: ByteString)
 --
@@ -269,9 +226,9 @@ extract bo bs o n
    | B.length bs == 0  = error "Empty ByteString"
    | otherwise         = mask n (foldlWithIndex' f 0 bs)
    where 
-      -- foldl' with index
-      foldlWithIndex' f b = fst . B.foldl' g (b,0)
-         where g (b,i) w = (f b w i, (i+1))
+      -- B.foldl' with index
+      foldlWithIndex' op b = fst . B.foldl' g (b,0)
+         where g (b',i) w = (op b' w i, (i+1))
 
       -- 'or' correctly shifted words
       f b w i   = b .|. (fromIntegral w `fastShift` off i)
@@ -286,8 +243,8 @@ extract bo bs o n
 
 
 -- | Generic readWord
-readWord :: (Num a, Bits a, FastBits a) => BitOrder -> Int -> S -> a
-readWord bo n (S bs o)
+readWord :: (Num a, Bits a, FastBits a) => Int -> S -> a
+readWord n (S bs o bo)
    | n == 0    = 0
    | o+n <= 8  = extract bo (unsafeTake 1 bs) o n
    | o+n <= 16 = extract bo (unsafeTake 2 bs) o n
@@ -299,30 +256,20 @@ readWord bo n (S bs o)
    | o+n <= 64 = extract bo (unsafeTake 8 bs) o n
    | otherwise = extract bo (unsafeTake ((o+n+7) `div` 8)  bs) o n
 
-readWordChecked :: (Num a, Bits a, FastBits a) => Int -> BitOrder -> Int -> S -> a
-readWordChecked m bo n s
+-- | Check that the number of bits to read is not greater than the first parameter
+{-# INLINE readWordChecked #-}
+readWordChecked :: (Num a, Bits a, FastBits a) => Int -> Int -> S -> a
+readWordChecked m n s
    | n > m     = error $ "Tried to read more than " ++ show m ++ " bits (" ++ show n ++")"
-   | otherwise = readWord bo n s
-
-{-# INLINE readWord8 #-}
-readWord8 :: BitOrder -> Int -> S -> Word8
-readWord8 = readWordChecked 8
-
-{-# INLINE readWord16 #-}
-readWord16 :: BitOrder -> Int -> S -> Word16
-readWord16 = readWordChecked 16
-
-{-# INLINE readWord32 #-}
-readWord32 :: BitOrder -> Int -> S -> Word32
-readWord32 = readWordChecked 32
-
-{-# INLINE readWord64 #-}
-readWord64 :: BitOrder -> Int -> S -> Word64
-readWord64 = readWordChecked 64
+   | otherwise = readWord n s
 
 -- | Read the given number of bytes and return them in Big-Endian order
-readByteString :: BitOrder -> Int -> S -> ByteString
-readByteString bo n (S bs o)
+--
+-- Examples:
+--    BB: xxxABCDE FGHIJKLM NOPQRxxx -> ABCDEFGH IJKLMNOP QRxxxxxx
+--    LB: NOPQRxxx FGHIJKLM xxxABCDE -> ABCDEFGH IJKLMNOP QRxxxxxx
+readByteString :: Int -> S -> ByteString
+readByteString n (S bs o bo)
   | o == 0    = unsafeTake n bs
   | otherwise = unsafePerformIO $ do
       let len = n+1
@@ -357,7 +304,7 @@ newtype BitGet a = B { runState :: S -> Get (S,a) }
 
 instance Monad BitGet where
   return x = B $ \s -> return (s,x)
-  fail str = B $ \(S inp n) -> putBackState inp n >> fail str
+  fail str = B $ \s -> putBackState s >> fail str
   (B f) >>= g = B $ \s -> do (s',a) <- f s
                              runState (g a) s'
 
@@ -373,20 +320,23 @@ instance Applicative BitGet where
 runBitGet :: BitGet a -> Get a
 runBitGet bg = do
   s <- mkInitState
-  ((S str' n),a) <- runState bg s
-  putBackState str' n
+  (s',a) <- runState bg s
+  putBackState s'
   return a
 
 mkInitState :: Get S
 mkInitState = do
-  str <- get
+  bs <- get
   put B.empty
-  return (S str 0)
+  return (S bs 0 BB)
 
-putBackState :: B.ByteString -> Int -> Get ()
-putBackState bs n = do
+putBackState :: S -> Get ()
+putBackState (S bs o _) = do
  remaining <- get
- put (B.drop (if n==0 then 0 else 1) bs `B.append` remaining)
+ let bs' = case o of
+      0 -> bs
+      _ -> unsafeDrop 1 bs
+ put (bs' `B.append` remaining)
 
 getState :: BitGet S
 getState = B $ \s -> return (s,s)
@@ -394,32 +344,47 @@ getState = B $ \s -> return (s,s)
 putState :: S -> BitGet ()
 putState s = B $ \_ -> return (s,())
 
+withState :: (S -> S) -> BitGet ()
+withState f = do
+   s <- getState
+   putState $! f s
+
 -- | Make sure there are at least @n@ bits.
 ensureBits :: Int -> BitGet ()
 ensureBits n = do
-  (S bs o) <- getState
+  (S bs o bo) <- getState
   if n <= (B.length bs * 8 - o)
     then return ()
     else do let currentBits = B.length bs * 8 - o
-            let byteCount = (n - currentBits + 7) `div` 8
+            let byteCount   = byte_offset (n - currentBits + 7)
             B $ \_ -> do B.ensureN byteCount
                          bs' <- B.get
                          put B.empty
-                         return (S (bs`append`bs') o, ())
+                         return (S (bs`append`bs') o bo, ())
 
 -- | Skip the given number of bits
 skipBits :: Int -> BitGet ()
 skipBits n = do
    ensureBits n
-   s <- getState
-   putState $! (incS n s)
+   withState (incS n)
 
 -- | Skip bits if necessary to align to the next byte
 alignByte :: BitGet ()
 alignByte = do
-   (S _ n) <- getState
-   when (n /= 0) $
-      skipBits (8-n)
+   (S _ o _) <- getState
+   when (o /= 0) $
+      skipBits (8-o)
+
+-- | Select the bit ordering
+selectBitOrder :: BitOrder -> BitGet ()
+selectBitOrder = withState . selectBitOrderS
+
+-- | Test whether all input has been consumed, i.e. there are no remaining
+-- undecoded bytes.
+isEmpty :: BitGet Bool
+isEmpty = B $ \ (S bs o bo) -> if B.null bs
+                               then B.isEmpty >>= \e -> return (S bs o bo, e)
+                               else return (S bs o bo, False)
 
 -- | Get 1 bit as a 'Bool'.
 getBool :: BitGet Bool
@@ -448,48 +413,99 @@ getByteString n = block (byteString n)
 -- | Get @n@ bytes as a lazy ByteString.
 getLazyByteString :: Int -> BitGet L.ByteString
 getLazyByteString n = do
-  (S _ o) <- getState
+  (S _ o bo) <- getState
   case o of
-    0 -> B $ \ (S bs o') -> do
-            putBackState bs o'
+    0 -> B $ \s -> do
+            putBackState s
             lbs <- B.getLazyByteString (fromIntegral n)
-            return (S B.empty 0, lbs)
+            return (S B.empty 0 bo, lbs)
     _ -> L.fromChunks . (:[]) <$> Data.Binary.Bits.Get.getByteString n
 
--- | Test whether all input has been consumed, i.e. there are no remaining
--- undecoded bytes.
-isEmpty :: BitGet Bool
-isEmpty = B $ \ (S bs o) -> if B.null bs
-                               then B.isEmpty >>= \e -> return (S bs o, e)
-                               else return (S bs o, False)
+
+
+
+
+-- | A block that will be read with only one boundary check. Needs to know the
+-- number of bits in advance.
+data Block a = Block Int (S -> a)
+
+instance Functor Block where
+  fmap f (Block i p) = Block i (\s -> f (p s))
+
+instance Applicative Block where
+  pure a = Block 0 (\_ -> a)
+  (Block i p) <*> (Block j q) = Block (i+j) (\s -> p s $ q (incS i s))
+  (Block i _)  *> (Block j q) = Block (i+j) (q . incS i)
+  (Block i p) <*  (Block j _) = Block (i+j) p
+
+-- | Get a block. Will be read with one single boundry check, and
+-- therefore requires a statically known number of bits.
+-- Build blocks using 'bool', 'word8', 'word16be', 'word32be', 'word64be',
+-- 'byteString' and 'Applicative'.
+block :: Block a -> BitGet a
+block (Block i p) = do
+  ensureBits i
+  s <- getState
+  putState $! (incS i s)
+  return $! p s
 
 -- | Read a 1 bit 'Bool'.
 bool :: Block Bool
-bool = Block 1 (readBool BB)
+bool = Block 1 readBool
 
 -- | Read @n@ bits as a 'Word8'. @n@ must be within @[0..8]@.
 word8 :: Int -> Block Word8
-word8 n = Block n (readWord8 BB n)
+word8 n = Block n (readWordChecked 8 n)
 
 -- | Read @n@ bits as a 'Word16'. @n@ must be within @[0..16]@.
 word16be :: Int -> Block Word16
-word16be n = Block n (readWord16 BB n)
+word16be n = Block n (readWordChecked 16 n)
 
 -- | Read @n@ bits as a 'Word32'. @n@ must be within @[0..32]@.
 word32be :: Int -> Block Word32
-word32be n = Block n (readWord32 BB n)
+word32be n = Block n (readWordChecked 32 n)
 
 -- | Read @n@ bits as a 'Word64'. @n@ must be within @[0..64]@.
 word64be :: Int -> Block Word64
-word64be n = Block n (readWord64 BB n)
+word64be n = Block n (readWordChecked 64 n)
 
 -- | Read @n@ bytes as a 'ByteString'.
 byteString :: Int -> Block ByteString
-byteString n | n > 0 = Block (n*8) (readByteString BB n)
+byteString n | n > 0 = Block (n*8) (readByteString n)
              | otherwise = Block 0 (\_ -> B.empty)
 
-------------------------------------------------------------------------
--- Unchecked shifts, from the package binary
+
+---------------------------------------------------------------------
+-- Unchecked shifts, from the "binary" package
+
+-- | Class for types supporting fast bit shifting
+class FastBits a where
+   fastShiftR :: a -> Int -> a
+   fastShiftL :: a -> Int -> a
+
+   {-# INLINE fastShift #-}
+   fastShift :: a -> Int -> a
+   fastShift x n
+      | n > 0 = fastShiftL x n
+      | n < 0 = fastShiftR x (negate n)
+      | otherwise = x
+
+instance FastBits Word8 where
+   fastShiftR = shiftr_w8
+   fastShiftL = shiftl_w8
+
+instance FastBits Word16 where
+   fastShiftR = shiftr_w16
+   fastShiftL = shiftl_w16
+
+instance FastBits Word32 where
+   fastShiftR = shiftr_w32
+   fastShiftL = shiftl_w32
+
+instance FastBits Word64 where
+   fastShiftR = shiftr_w64
+   fastShiftL = shiftl_w64
+
 
 shiftl_w8  :: Word8  -> Int -> Word8
 shiftl_w16 :: Word16 -> Int -> Word16

--- a/Data/Binary/Bits/Get.hs
+++ b/Data/Binary/Bits/Get.hs
@@ -268,8 +268,8 @@ extract bo bs o n
       rev = case bo of
          LL -> reverseBits n
          BL -> reverseBits n
-         BB  -> id
-         LB  -> id
+         BB -> id
+         LB -> id
 
 
 -- | Generic readWord
@@ -296,15 +296,15 @@ readWordChecked m n s
 -- | Read the given number of bytes and return them in Big-Endian order
 --
 -- Examples:
---    BB: xxxABCDE FGHIJKLM NOPQRxxx -> ABCDEFGH IJKLMNOP QRxxxxxx
---    LB: NOPQRxxx FGHIJKLM xxxABCDE -> ABCDEFGH IJKLMNOP QRxxxxxx
---    BL: xxxRQPON MLKJIHGF EDCBAxxx -> ABCDEFGH IJKLMNOP QRxxxxxx
---    LL: EDCBAxxx MLKJIHGF xxxRQPON -> ABCDEFGH IJKLMNOP QRxxxxxx
+--    BB: xxxABCDE FGHIJKLM NOPxxxxx -> ABCDEFGH IJKLMNOP
+--    LB: LMNOPxxx DEFGHIJK xxxxxABC -> ABCDEFGH IJKLMNOP
+--    BL: xxxPONML KJIHGFED CBAxxxxx -> ABCDEFGH IJKLMNOP
+--    LL: EDCBAxxx MLKJIHGF xxxxxPON -> ABCDEFGH IJKLMNOP
 readByteString :: Int -> S -> ByteString
 readByteString n (S bs o bo) =
    let 
       bs' = unsafeTake (n+1) bs
-      rev = B.map (reverseBits 9)
+      rev = B.map (reverseBits 8)
    in case (o,bo) of
       (0,BB) -> unsafeTake n bs
       (0,LB) -> B.reverse (unsafeTake n bs)

--- a/Data/Binary/Bits/Get.hs
+++ b/Data/Binary/Bits/Get.hs
@@ -4,6 +4,7 @@
 -- |
 -- Module      :  Data.Binary.Bits.Get
 -- Copyright   :  (c) Lennart Kolmodin 2010-2011
+--                (c) Sylvain Henry 2015
 -- License     :  BSD3-style (see LICENSE)
 --
 -- Maintainer  :  kolmodin@gmail.com

--- a/Data/Binary/Bits/Get.hs
+++ b/Data/Binary/Bits/Get.hs
@@ -62,6 +62,9 @@ module Data.Binary.Bits.Get
             -- ** Get bytes
             , getBool
             , getWord8
+            , getWord16
+            , getWord32
+            , getWord64
             , getWord16be
             , getWord32be
             , getWord64be
@@ -79,6 +82,9 @@ module Data.Binary.Bits.Get
             -- ** Read in Blocks
             , bool
             , word8
+            , word16
+            , word32
+            , word64
             , word16be
             , word32be
             , word64be
@@ -395,16 +401,28 @@ getWord8 :: Int -> BitGet Word8
 getWord8 n = block (word8 n)
 
 -- | Get @n@ bits as a 'Word16'. @n@ must be within @[0..16]@.
+getWord16 :: Int -> BitGet Word16
+getWord16 n = block (word16 n)
+
 getWord16be :: Int -> BitGet Word16
-getWord16be n = block (word16be n)
+getWord16be = getWord16
+{-# DEPRECATED getWord16be "Use 'getWord16' instead" #-}
 
 -- | Get @n@ bits as a 'Word32'. @n@ must be within @[0..32]@.
+getWord32 :: Int -> BitGet Word32
+getWord32 n = block (word32 n)
+
 getWord32be :: Int -> BitGet Word32
-getWord32be n = block (word32be n)
+getWord32be = getWord32
+{-# DEPRECATED getWord32be "Use 'getWord32' instead" #-}
 
 -- | Get @n@ bits as a 'Word64'. @n@ must be within @[0..64]@.
+getWord64 :: Int -> BitGet Word64
+getWord64 n = block (word64 n)
+
 getWord64be :: Int -> BitGet Word64
-getWord64be n = block (word64be n)
+getWord64be = getWord64
+{-# DEPRECATED getWord64be "Use 'getWord64' instead" #-}
 
 -- | Get @n@ bytes as a 'ByteString'.
 getByteString :: Int -> BitGet ByteString
@@ -458,16 +476,28 @@ word8 :: Int -> Block Word8
 word8 n = Block n (readWordChecked 8 n)
 
 -- | Read @n@ bits as a 'Word16'. @n@ must be within @[0..16]@.
+word16 :: Int -> Block Word16
+word16 n = Block n (readWordChecked 16 n)
+
 word16be :: Int -> Block Word16
-word16be n = Block n (readWordChecked 16 n)
+word16be = word16
+{-# DEPRECATED word16be "Use 'word16' instead" #-}
 
 -- | Read @n@ bits as a 'Word32'. @n@ must be within @[0..32]@.
+word32 :: Int -> Block Word32
+word32 n = Block n (readWordChecked 32 n)
+
 word32be :: Int -> Block Word32
-word32be n = Block n (readWordChecked 32 n)
+word32be = word32
+{-# DEPRECATED word32be "Use 'word32' instead" #-}
 
 -- | Read @n@ bits as a 'Word64'. @n@ must be within @[0..64]@.
+word64 :: Int -> Block Word64
+word64 n = Block n (readWordChecked 64 n)
+
 word64be :: Int -> Block Word64
-word64be n = Block n (readWordChecked 64 n)
+word64be = word64
+{-# DEPRECATED word64be "Use 'word64' instead" #-}
 
 -- | Read @n@ bytes as a 'ByteString'.
 byteString :: Int -> Block ByteString

--- a/Data/Binary/Bits/Get.hs
+++ b/Data/Binary/Bits/Get.hs
@@ -58,6 +58,7 @@ module Data.Binary.Bits.Get
             , BitOrder(..)
             , runBitGet
             , selectBitOrder
+            , withBitOrder
 
             -- ** Get bytes
             , getBool
@@ -358,6 +359,13 @@ withState f = do
    s <- getState
    putState $! f s
 
+-- | Get the bit ordering
+getBitOrder :: BitGet BitOrder
+getBitOrder = do
+   (S _ _ bo) <- getState
+   return bo
+
+
 -- | Make sure there are at least @n@ bits.
 ensureBits :: Int -> BitGet ()
 ensureBits n = do
@@ -387,6 +395,16 @@ alignByte = do
 -- | Select the bit ordering
 selectBitOrder :: BitOrder -> BitGet ()
 selectBitOrder = withState . selectBitOrderS
+
+withBitOrder :: BitOrder -> BitGet a -> BitGet a
+withBitOrder bo f = do
+   bo' <- getBitOrder
+   selectBitOrder bo
+   r <- f
+   selectBitOrder bo'
+   return r
+
+   
 
 -- | Test whether all input has been consumed, i.e. there are no remaining
 -- undecoded bytes.

--- a/Data/Binary/Bits/Get.hs
+++ b/Data/Binary/Bits/Get.hs
@@ -57,6 +57,7 @@ module Data.Binary.Bits.Get
               BitGet
             , BitOrder(..)
             , runBitGet
+            , getBitOrder
             , selectBitOrder
             , withBitOrder
 

--- a/Data/Binary/Bits/Get.hs
+++ b/Data/Binary/Bits/Get.hs
@@ -64,6 +64,10 @@ module Data.Binary.Bits.Get
             , getWord32be
             , getWord64be
 
+            -- ** Skip bits
+            , skipBits
+            , alignByte
+
             -- * Blocks
 
             -- $blocks
@@ -93,6 +97,7 @@ import Data.ByteString.Unsafe
 import Data.Bits
 import Data.Word
 import Control.Applicative
+import Control.Monad (when)
 
 import Prelude as P
 
@@ -391,6 +396,20 @@ ensureBits n = do
                          bs' <- B.get
                          put B.empty
                          return (S (bs`append`bs') o, ())
+
+-- | Skip the given number of bits
+skipBits :: Int -> BitGet ()
+skipBits n = do
+   ensureBits n
+   s <- getState
+   putState $! (incS n s)
+
+-- | Skip bits if necessary to align on a byte
+alignByte :: BitGet ()
+alignByte = do
+   (S _ n) <- getState
+   when (n /= 0) $
+      skipBits (8-n)
 
 -- | Get 1 bit as a 'Bool'.
 getBool :: BitGet Bool

--- a/Data/Binary/Bits/Internal.hs
+++ b/Data/Binary/Bits/Internal.hs
@@ -29,8 +29,8 @@ import GHC.Word
 #endif
 
 -- | make_mask 3 = 00000111
-make_mask :: (FastBits a, Num a) => Int -> a
-make_mask n = (1 `fastShiftL` fromIntegral n) - 1
+make_mask :: (Bits a, Num a) => Int -> a
+make_mask n = (1 `shiftL` fromIntegral n) - 1
 {-# SPECIALIZE make_mask :: Int -> Int #-}
 {-# SPECIALIZE make_mask :: Int -> Word #-}
 {-# SPECIALIZE make_mask :: Int -> Word8 #-}
@@ -39,7 +39,7 @@ make_mask n = (1 `fastShiftL` fromIntegral n) - 1
 {-# SPECIALIZE make_mask :: Int -> Word64 #-}
 
 -- | Keep only the n least-significant bits of the given value
-mask :: (FastBits a, Num a) => Int -> a -> a
+mask :: (Bits a, Num a) => Int -> a -> a
 mask n v = v .&. make_mask n
 {-# INLINE mask #-}
 

--- a/Data/Binary/Bits/Internal.hs
+++ b/Data/Binary/Bits/Internal.hs
@@ -1,0 +1,155 @@
+{-# LANGUAGE RankNTypes, MagicHash, BangPatterns, CPP #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Binary.Bits.Get
+-- Copyright   :  (c) Lennart Kolmodin 2010-2011
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  kolmodin@gmail.com
+-- Stability   :  experimental
+-- Portability :  portable (should run where the package binary runs)
+
+module Data.Binary.Bits.Internal
+   ( make_mask
+   , mask
+   , bit_offset
+   , byte_offset
+   , reverseBits
+   , FastBits(..)
+   )
+where
+
+import Data.Word
+import Data.Bits
+
+#if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
+import GHC.Base
+import GHC.Word
+#endif
+
+-- | make_mask 3 = 00000111
+make_mask :: (FastBits a, Num a) => Int -> a
+make_mask n = (1 `fastShiftL` fromIntegral n) - 1
+{-# SPECIALIZE make_mask :: Int -> Int #-}
+{-# SPECIALIZE make_mask :: Int -> Word #-}
+{-# SPECIALIZE make_mask :: Int -> Word8 #-}
+{-# SPECIALIZE make_mask :: Int -> Word16 #-}
+{-# SPECIALIZE make_mask :: Int -> Word32 #-}
+{-# SPECIALIZE make_mask :: Int -> Word64 #-}
+
+-- | Keep only the n least-significant bits of the given value
+mask :: (FastBits a, Num a) => Int -> a -> a
+mask n v = v .&. make_mask n
+{-# INLINE mask #-}
+
+-- | Compute bit offset (equivalent to x `mod` 8 but faster)
+bit_offset :: Int -> Int
+bit_offset n = make_mask 3 .&. n
+{-# INLINE bit_offset #-}
+
+-- | Compute byte offset (equivalent to x `div` 8 but faster)
+byte_offset :: Int -> Int
+byte_offset n = n `shiftR` 3
+{-# INLINE byte_offset #-}
+
+-- | Reverse the @n@ least important bits of the given value
+reverseBits :: (Num a, FastBits a, Bits a) => Int -> a -> a
+reverseBits n value = rec value n 0
+   where
+      -- rec v i r, where
+      --    v is orginal value shifted
+      --    i is the remaining number of bits
+      --    r is current value
+      rec 0 0 r = r
+      rec 0 i r = r `fastShiftL` i
+      rec v i r = rec (v `fastShiftR` 1) (i-1) ((r `fastShiftL` 1) .|. (v .&. 0x1))
+
+
+---------------------------------------------------------------------
+-- Unchecked shifts, from the "binary" package
+
+-- | Class for types supporting fast bit shifting
+class Bits a => FastBits a where
+   fastShiftR :: a -> Int -> a
+   fastShiftR = shiftR
+
+   fastShiftL :: a -> Int -> a
+   fastShiftL = shiftL
+
+   {-# INLINE fastShift #-}
+   fastShift :: a -> Int -> a
+   fastShift x n
+      | n > 0 = fastShiftL x n
+      | n < 0 = fastShiftR x (negate n)
+      | otherwise = x
+
+instance FastBits Word8 where
+   fastShiftR = shiftr_w8
+   fastShiftL = shiftl_w8
+
+instance FastBits Word16 where
+   fastShiftR = shiftr_w16
+   fastShiftL = shiftl_w16
+
+instance FastBits Word32 where
+   fastShiftR = shiftr_w32
+   fastShiftL = shiftl_w32
+
+instance FastBits Word64 where
+   fastShiftR = shiftr_w64
+   fastShiftL = shiftl_w64
+
+instance FastBits Int
+
+instance FastBits Word
+
+
+shiftl_w8  :: Word8  -> Int -> Word8
+shiftl_w16 :: Word16 -> Int -> Word16
+shiftl_w32 :: Word32 -> Int -> Word32
+shiftl_w64 :: Word64 -> Int -> Word64
+
+shiftr_w8  :: Word8  -> Int -> Word8
+shiftr_w16 :: Word16 -> Int -> Word16
+shiftr_w32 :: Word32 -> Int -> Word32
+shiftr_w64 :: Word64 -> Int -> Word64
+
+#if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
+shiftl_w8  (W8# w)  (I# i) = W8#  (w `uncheckedShiftL#`   i)
+shiftl_w16 (W16# w) (I# i) = W16# (w `uncheckedShiftL#`   i)
+shiftl_w32 (W32# w) (I# i) = W32# (w `uncheckedShiftL#`   i)
+
+shiftr_w8  (W8#  w) (I# i) = W8# (w `uncheckedShiftRL#`   i)
+shiftr_w16 (W16# w) (I# i) = W16# (w `uncheckedShiftRL#`  i)
+shiftr_w32 (W32# w) (I# i) = W32# (w `uncheckedShiftRL#`  i)
+
+
+#if WORD_SIZE_IN_BITS < 64
+shiftl_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftL64#`  i)
+shiftr_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftRL64#` i)
+
+#if __GLASGOW_HASKELL__ <= 606
+-- Exported by GHC.Word in GHC 6.8 and higher
+foreign import ccall unsafe "stg_uncheckedShiftL64"
+    uncheckedShiftL64#     :: Word64# -> Int# -> Word64#
+foreign import ccall unsafe "stg_uncheckedShiftRL64"
+    uncheckedShiftRL64#     :: Word64# -> Int# -> Word64#
+#endif
+
+#else
+shiftl_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftL#`  i)
+shiftr_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftRL#` i)
+#endif
+
+#else
+shiftl_w8  = shiftL
+shiftl_w16 = shiftL
+shiftl_w32 = shiftL
+shiftl_w64 = shiftL
+
+shiftr_w8 = shiftR
+shiftr_w16 = shiftR
+shiftr_w32 = shiftR
+shiftr_w64 = shiftR
+#endif

--- a/Data/Binary/Bits/Put.hs
+++ b/Data/Binary/Bits/Put.hs
@@ -189,3 +189,8 @@ instance Monad BitPut where
         PairS b s'' = run (k a) s'
     in PairS b s''
   return x = BitPut $ \s -> PairS x s
+
+instance BitOrderable BitPut where
+   setBitOrder bo = BitPut $ \(S bu b o _) -> PairS () (S bu b o bo)
+
+   getBitOrder = BitPut $ \s@(S _ _ _ bo) -> PairS bo s

--- a/Data/Binary/Bits/Put.hs
+++ b/Data/Binary/Bits/Put.hs
@@ -23,6 +23,9 @@ module Data.Binary.Bits.Put
 
           -- ** Words
           , putWord8
+          , putWord16
+          , putWord32
+          , putWord64
           , putWord16be
           , putWord32be
           , putWord64be
@@ -111,16 +114,28 @@ putWord8 :: Int -> Word8 -> BitPut ()
 putWord8 = putWord
 
 -- | Put the @n@ lower bits of a 'Word16'.
+putWord16 :: Int -> Word16 -> BitPut ()
+putWord16 = putWord
+
 putWord16be :: Int -> Word16 -> BitPut ()
 putWord16be = putWord
+{-# DEPRECATED putWord16be "Use 'putWord16' instead" #-}
 
 -- | Put the @n@ lower bits of a 'Word32'.
+putWord32 :: Int -> Word32 -> BitPut ()
+putWord32 = putWord
+
 putWord32be :: Int -> Word32 -> BitPut ()
 putWord32be = putWord
+{-# DEPRECATED putWord32be "Use 'putWord32' instead" #-}
 
 -- | Put the @n@ lower bits of a 'Word64'.
+putWord64 :: Int -> Word64 -> BitPut ()
+putWord64 = putWord
+
 putWord64be :: Int -> Word64 -> BitPut ()
 putWord64be = putWord
+{-# DEPRECATED putWord64be "Use 'putWord64' instead" #-}
 
 -- | Put a 'ByteString'.
 --

--- a/Data/Binary/Bits/Put.hs
+++ b/Data/Binary/Bits/Put.hs
@@ -35,6 +35,7 @@ import qualified Data.Binary.Builder as B
 import Data.Binary.Builder ( Builder )
 import qualified Data.Binary.Put as Put
 import Data.Binary.Put ( Put )
+import Data.Binary.Bits.Internal
 
 import Data.ByteString
 
@@ -53,15 +54,6 @@ data S = S !Builder !Word8 !Int
 putBool :: Bool -> BitPut ()
 putBool b = putWord8 1 (if b then 0xff else 0x00)
 
--- | make_mask 3 = 00000111
-make_mask :: (Bits a, Num a) => Int -> a
-make_mask n = (1 `shiftL` fromIntegral n) - 1
-{-# SPECIALIZE make_mask :: Int -> Int #-}
-{-# SPECIALIZE make_mask :: Int -> Word #-}
-{-# SPECIALIZE make_mask :: Int -> Word8 #-}
-{-# SPECIALIZE make_mask :: Int -> Word16 #-}
-{-# SPECIALIZE make_mask :: Int -> Word32 #-}
-{-# SPECIALIZE make_mask :: Int -> Word64 #-}
 
 -- | Put the @n@ lower bits of a 'Word8'.
 putWord8 :: Int -> Word8 -> BitPut ()

--- a/binary-bits.cabal
+++ b/binary-bits.cabal
@@ -24,7 +24,9 @@ library
 
   exposed-modules:     Data.Binary.Bits ,
                        Data.Binary.Bits.Put ,
-                       Data.Binary.Bits.Get
+                       Data.Binary.Bits.Get ,
+                       Data.Binary.Bits.BitOrder
+  other-modules:       Data.Binary.Bits.Internal
 
   default-language:    Haskell98
 

--- a/binary-bits.cabal
+++ b/binary-bits.cabal
@@ -1,6 +1,6 @@
 -- http://www.haskell.org/cabal/release/cabal-latest/doc/users-guide/
 name:                binary-bits
-version:             0.5.1
+version:             0.6
 synopsis:            Bit parsing/writing on top of binary.
 description:         Bit parsing/writing on top of binary. Provides functions to
                      read and write bits to and from 8\/16\/32\/64 words.

--- a/binary-bits.cabal
+++ b/binary-bits.cabal
@@ -1,6 +1,6 @@
 -- http://www.haskell.org/cabal/release/cabal-latest/doc/users-guide/
 name:                binary-bits
-version:             0.5
+version:             0.5.1
 synopsis:            Bit parsing/writing on top of binary.
 description:         Bit parsing/writing on top of binary. Provides functions to
                      read and write bits to and from 8\/16\/32\/64 words.


### PR DESCRIPTION
Hi,

I needed to have a "alignByte" function: if necessary, it skips some bits to align on a Byte boundary. It is implemented in the first patch.

The second patch fixes trivial but annoying warnings from GHC. The last one bumps the version.

Can you review these patchs and submit a new package on Hackage please?

Best regards
Sylvain
