### PR TITLE
Support bit ordering, bit skipping and byte alignment

### DIFF
--- a/Data/Binary/Bits.hs
+++ b/Data/Binary/Bits.hs
@@ -33,13 +33,13 @@ instance BinaryBit Word8 where
   getBits = getWord8
 
 instance BinaryBit Word16 where
-  putBits = putWord16be
-  getBits = getWord16be
+  putBits = putWord16
+  getBits = getWord16
 
 instance BinaryBit Word32 where
-  putBits = putWord32be
-  getBits = getWord32be
+  putBits = putWord32
+  getBits = getWord32
 
 instance BinaryBit Word64 where
-  putBits = putWord64be
-  getBits = getWord64be
+  putBits = putWord64
+  getBits = getWord64

--- a/Data/Binary/Bits/Alignment.hs
+++ b/Data/Binary/Bits/Alignment.hs
@@ -1,0 +1,22 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Binary.Bits.Get
+-- Copyright   :  (c) Lennart Kolmodin 2010-2011
+--                (c) Sylvain Henry 2015
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  kolmodin@gmail.com
+-- Stability   :  experimental
+-- Portability :  portable (should run where the package binary runs)
+
+module Data.Binary.Bits.Alignment
+   ( Alignable(..)
+   )
+where
+
+class Monad m => Alignable m where
+   -- | Skip the given number of bits
+   skipBits :: Int -> m ()
+
+   -- | Skip bits if necessary to align to the next byte
+   alignByte :: m ()

--- a/Data/Binary/Bits/BitOrder.hs
+++ b/Data/Binary/Bits/BitOrder.hs
@@ -19,9 +19,9 @@ where
 --
 -- E.g. two words of 5 bits: ABCDE, VWXYZ
 --    - BB: ABCDEVWX YZxxxxxx
---    - LB: XYZABCDE xxxxxxVW
+--    - LL: XYZABCDE xxxxxxVW
 --    - BL: EDCBAZYX WVxxxxxx
---    - LL: XWVEDCBA xxxxxxZY
+--    - LB: XWVEDCBA xxxxxxZY
 data BitOrder
    = BB  -- ^ Big-endian bytes and bits
    | LB  -- ^ Little-endian bytes, big-endian bits

--- a/Data/Binary/Bits/BitOrder.hs
+++ b/Data/Binary/Bits/BitOrder.hs
@@ -1,0 +1,47 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Binary.Bits.Get
+-- Copyright   :  (c) Lennart Kolmodin 2010-2011
+--                (c) Sylvain Henry 2015
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  kolmodin@gmail.com
+-- Stability   :  experimental
+-- Portability :  portable (should run where the package binary runs)
+
+module Data.Binary.Bits.BitOrder
+   ( BitOrder(..)
+   , BitOrderable(..)
+   )
+where
+
+-- | Bit order
+--
+-- E.g. two words of 5 bits: ABCDE, VWXYZ
+--    - BB: ABCDEVWX YZxxxxxx
+--    - LB: XYZABCDE xxxxxxVW
+--    - BL: EDCBAZYX WVxxxxxx
+--    - LL: XWVEDCBA xxxxxxZY
+data BitOrder
+   = BB  -- ^ Big-endian bytes and bits
+   | LB  -- ^ Little-endian bytes, big-endian bits
+   | BL  -- ^ Big-endian bytes, little-endian bits
+   | LL  -- ^ Little-endian bytes and bits
+   deriving (Show)
+
+
+class Monad m => BitOrderable m where
+   -- | Set the current bit-order
+   setBitOrder :: BitOrder -> m ()
+
+   -- | Retrieve the current bit-order
+   getBitOrder    :: m BitOrder
+
+   -- | Perform the given action with the given bit-order
+   withBitOrder   :: BitOrder -> m a -> m a
+   withBitOrder bo act = do
+      bo' <- getBitOrder
+      setBitOrder bo
+      r <- act
+      setBitOrder bo'
+      return r

--- a/Data/Binary/Bits/Get.hs
+++ b/Data/Binary/Bits/Get.hs
@@ -179,8 +179,8 @@ readBool :: S -> Bool
 readBool (S bs o bo) = case bo of
    BB -> testBit (unsafeHead bs) (7-o)
    BL -> testBit (unsafeHead bs) (7-o)
-   LB -> testBit (unsafeHead bs) o
    LL -> testBit (unsafeHead bs) o
+   LB -> testBit (unsafeHead bs) o
 
 -- | Extract a range of bits from (ws :: ByteString)
 --
@@ -203,17 +203,17 @@ extract bo bs o n
 
       -- shift offset depending on the byte position (0..B.length-1)
       off i = case bo of
-         LB -> 8*i - o
          LL -> 8*i - o
+         LB -> 8*i - o
          BB -> (B.length bs -1 - i) * 8 - r
          BL -> (B.length bs -1 - i) * 8 - r
 
       -- reverse bits if necessary
       rev = case bo of
-         LL -> reverseBits n
+         LB -> reverseBits n
          BL -> reverseBits n
          BB -> id
-         LB -> id
+         LL -> id
 
 
 -- | Generic readWord
@@ -234,9 +234,9 @@ readWordChecked m n s
 --
 -- Examples:
 --    BB: xxxABCDE FGHIJKLM NOPxxxxx -> ABCDEFGH IJKLMNOP
---    LB: LMNOPxxx DEFGHIJK xxxxxABC -> ABCDEFGH IJKLMNOP
+--    LL: LMNOPxxx DEFGHIJK xxxxxABC -> ABCDEFGH IJKLMNOP
 --    BL: xxxPONML KJIHGFED CBAxxxxx -> ABCDEFGH IJKLMNOP
---    LL: EDCBAxxx MLKJIHGF xxxxxPON -> ABCDEFGH IJKLMNOP
+--    LB: EDCBAxxx MLKJIHGF xxxxxPON -> ABCDEFGH IJKLMNOP
 readByteString :: Int -> S -> ByteString
 readByteString n (S bs o bo) =
    let 
@@ -245,12 +245,12 @@ readByteString n (S bs o bo) =
       rev  = B.map (reverseBits 8)
    in case (o,bo) of
       (0,BB) -> bs''
-      (0,LB) -> B.reverse bs''
-      (0,LL) -> rev bs''
+      (0,LL) -> B.reverse bs''
+      (0,LB) -> rev bs''
       (0,BL) -> rev . B.reverse $ bs''
-      (_,LB) -> readByteString n (S (B.reverse bs') (8-o) BB)
+      (_,LL) -> readByteString n (S (B.reverse bs') (8-o) BB)
       (_,BL) -> rev . B.reverse $ readByteString n (S bs' o BB)
-      (_,LL) -> rev . B.reverse $ readByteString n (S bs' o LB)
+      (_,LB) -> rev . B.reverse $ readByteString n (S bs' o LL)
       (_,BB) -> unsafePerformIO $ do
          let len = n+1
          ptr <- mallocBytes len

--- a/Data/Binary/Bits/Get.hs
+++ b/Data/Binary/Bits/Get.hs
@@ -4,6 +4,7 @@
 -- |
 -- Module      :  Data.Binary.Bits.Get
 -- Copyright   :  (c) Lennart Kolmodin 2010-2011
+--                (c) Sylvain Henry 2015
 -- License     :  BSD3-style (see LICENSE)
 --
 -- Maintainer  :  kolmodin@gmail.com
@@ -60,9 +61,16 @@ module Data.Binary.Bits.Get
             -- ** Get bytes
             , getBool
             , getWord8
+            , getWord16
+            , getWord32
+            , getWord64
             , getWord16be
             , getWord32be
             , getWord64be
+
+            -- ** Skip bits
+            , skipBits
+            , alignByte
 
             -- * Blocks
 
@@ -73,6 +81,9 @@ module Data.Binary.Bits.Get
             -- ** Read in Blocks
             , bool
             , word8
+            , word16
+            , word32
+            , word64
             , word16be
             , word32be
             , word64be
@@ -83,24 +94,26 @@ module Data.Binary.Bits.Get
 
             ) where
 
-import Data.Binary.Get as B ( runGet, Get, getByteString, getLazyByteString, isEmpty )
+import Data.Binary.Get as B ( Get, getLazyByteString, isEmpty )
 import Data.Binary.Get.Internal as B ( get, put, ensureN )
+import Data.Binary.Bits.BitOrder
+import Data.Binary.Bits.Internal
+import Data.Binary.Bits.Alignment
 
 import Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
 import Data.ByteString.Unsafe
+import Foreign.Marshal.Alloc (mallocBytes)
+import Foreign.Ptr
+import Foreign.Storable (poke)
+import System.IO.Unsafe (unsafePerformIO)
 
 import Data.Bits
 import Data.Word
 import Control.Applicative
+import Control.Monad (when,foldM_)
 
 import Prelude as P
-
-#if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
-import GHC.Base
-import GHC.Word
-#endif
-
 
 -- $bitget
 -- Parse bits using a monad.
@@ -149,10 +162,256 @@ import GHC.Word
 -- @
 
 data S = S {-# UNPACK #-} !ByteString -- Input
-           {-# UNPACK #-} !Int -- Bit offset (0-7)
+           {-# UNPACK #-} !Int        -- Bit offset (0-7)
+                          !BitOrder   -- Bit order
           deriving (Show)
 
--- | A block that will be read with only one boundry check. Needs to know the
+-- | Increment the current bit offset
+incS :: Int -> S -> S
+incS o (S bs n bo) = S (unsafeDrop d bs) n' bo
+   where
+      !o' = (n+o)
+      !d  = byte_offset o'
+      !n' = bit_offset o'
+
+-- | Read a single bit
+readBool :: S -> Bool
+readBool (S bs o bo) = case bo of
+   BB -> testBit (unsafeHead bs) (7-o)
+   BL -> testBit (unsafeHead bs) (7-o)
+   LB -> testBit (unsafeHead bs) o
+   LL -> testBit (unsafeHead bs) o
+
+-- | Extract a range of bits from (ws :: ByteString)
+--
+-- Constraint: 8 * (length ws -1 ) < o+n <= 8 * length ws
+extract :: (Num a, FastBits a) => BitOrder -> ByteString -> Int -> Int -> a
+extract bo bs o n     
+   | n == 0            = 0
+   | B.length bs == 0  = error "Empty ByteString"
+   | otherwise         = rev . mask n . foldlWithIndex' f 0 $ bs
+   where 
+      -- B.foldl' with index
+      foldlWithIndex' op b = fst . B.foldl' g (b,0)
+         where g (b',i) w = (op b' w i, (i+1))
+
+      -- 'or' correctly shifted words
+      f b w i = b .|. (fromIntegral w `fastShift` off i)
+
+      -- co-offset
+      r = B.length bs * 8 - (o + n)
+
+      -- shift offset depending on the byte position (0..B.length-1)
+      off i = case bo of
+         LB -> 8*i - o
+         LL -> 8*i - o
+         BB -> (B.length bs -1 - i) * 8 - r
+         BL -> (B.length bs -1 - i) * 8 - r
+
+      -- reverse bits if necessary
+      rev = case bo of
+         LL -> reverseBits n
+         BL -> reverseBits n
+         BB -> id
+         LB -> id
+
+
+-- | Generic readWord
+readWord :: (Num a, FastBits a) => Int -> S -> a
+readWord n (S bs o bo)
+   | n == 0    = 0
+   | otherwise = extract bo (unsafeTake nbytes bs) o n
+   where nbytes = byte_offset (o+n+7)
+
+-- | Check that the number of bits to read is not greater than the first parameter
+{-# INLINE readWordChecked #-}
+readWordChecked :: (Num a, FastBits a) => Int -> Int -> S -> a
+readWordChecked m n s
+   | n > m     = error $ "Tried to read more than " ++ show m ++ " bits (" ++ show n ++")"
+   | otherwise = readWord n s
+
+-- | Read the given number of bytes and return them in Big-Endian order
+--
+-- Examples:
+--    BB: xxxABCDE FGHIJKLM NOPxxxxx -> ABCDEFGH IJKLMNOP
+--    LB: LMNOPxxx DEFGHIJK xxxxxABC -> ABCDEFGH IJKLMNOP
+--    BL: xxxPONML KJIHGFED CBAxxxxx -> ABCDEFGH IJKLMNOP
+--    LL: EDCBAxxx MLKJIHGF xxxxxPON -> ABCDEFGH IJKLMNOP
+readByteString :: Int -> S -> ByteString
+readByteString n (S bs o bo) =
+   let 
+      bs'  = unsafeTake (n+1) bs
+      bs'' = unsafeTake n bs
+      rev  = B.map (reverseBits 8)
+   in case (o,bo) of
+      (0,BB) -> bs''
+      (0,LB) -> B.reverse bs''
+      (0,LL) -> rev bs''
+      (0,BL) -> rev . B.reverse $ bs''
+      (_,LB) -> readByteString n (S (B.reverse bs') (8-o) BB)
+      (_,BL) -> rev . B.reverse $ readByteString n (S bs' o BB)
+      (_,LL) -> rev . B.reverse $ readByteString n (S bs' o LB)
+      (_,BB) -> unsafePerformIO $ do
+         let len = n+1
+         ptr <- mallocBytes len
+         let f r i = do
+               let
+                  w  = unsafeIndex bs (len-i)
+                  w' = (w `fastShiftL` o) .|. r
+                  r' = w `fastShiftR` (8-o)
+               poke (ptr `plusPtr` (len-i)) w'
+               return r'
+         foldM_ f 0 [1..len]
+         unsafeInit <$> unsafePackMallocCStringLen (ptr,len)
+
+
+------------------------------------------------------------------------
+-- | 'BitGet' is a monad, applicative and a functor. See 'runBitGet'
+-- for how to run it.
+newtype BitGet a = B { runState :: S -> Get (S,a) }
+
+instance Monad BitGet where
+  return x = B $ \s -> return (s,x)
+  fail str = B $ \s -> putBackState s >> fail str
+  (B f) >>= g = B $ \s -> do (s',a) <- f s
+                             runState (g a) s'
+
+instance Functor BitGet where
+  fmap f m = m >>= \a -> return (f a)
+
+instance Applicative BitGet where
+  pure x = return x
+  fm <*> m = fm >>= \f -> m >>= \v -> return (f v)
+
+instance BitOrderable BitGet where
+   setBitOrder bo = do
+      (S bs o _) <- getState
+      putState (S bs o bo)
+
+   getBitOrder = do
+      (S _ _ bo) <- getState
+      return bo
+
+instance Alignable BitGet where
+   -- | Skip the given number of bits
+   skipBits n = do
+      ensureBits n
+      withState (incS n)
+
+   -- | Skip bits if necessary to align to the next byte
+   alignByte = do
+      (S _ o _) <- getState
+      when (o /= 0) $
+         skipBits (8-o)
+
+
+
+-- | Run a 'BitGet' within the Binary packages 'Get' monad. If a byte has
+-- been partially consumed it will be discarded once 'runBitGet' is finished.
+runBitGet :: BitGet a -> Get a
+runBitGet bg = do
+  s <- mkInitState
+  (s',a) <- runState bg s
+  putBackState s'
+  return a
+
+mkInitState :: Get S
+mkInitState = do
+  bs <- get
+  put B.empty
+  return (S bs 0 BB)
+
+putBackState :: S -> Get ()
+putBackState (S bs o _) = do
+ remaining <- get
+ let bs' = case o of
+      0 -> bs
+      _ -> unsafeDrop 1 bs
+ put (bs' `B.append` remaining)
+
+getState :: BitGet S
+getState = B $ \s -> return (s,s)
+
+putState :: S -> BitGet ()
+putState s = B $ \_ -> return (s,())
+
+withState :: (S -> S) -> BitGet ()
+withState f = do
+   s <- getState
+   putState $! f s
+
+-- | Make sure there are at least @n@ bits.
+ensureBits :: Int -> BitGet ()
+ensureBits n = do
+  (S bs o bo) <- getState
+  if n <= (B.length bs * 8 - o)
+    then return ()
+    else do let currentBits = B.length bs * 8 - o
+            let byteCount   = byte_offset (n - currentBits + 7)
+            B $ \_ -> do B.ensureN byteCount
+                         bs' <- B.get
+                         put B.empty
+                         return (S (bs`append`bs') o bo, ())
+
+-- | Test whether all input has been consumed, i.e. there are no remaining
+-- undecoded bytes.
+isEmpty :: BitGet Bool
+isEmpty = B $ \ (S bs o bo) -> if B.null bs
+                               then B.isEmpty >>= \e -> return (S bs o bo, e)
+                               else return (S bs o bo, False)
+
+-- | Get 1 bit as a 'Bool'.
+getBool :: BitGet Bool
+getBool = block bool
+
+-- | Get @n@ bits as a 'Word8'. @n@ must be within @[0..8]@.
+getWord8 :: Int -> BitGet Word8
+getWord8 n = block (word8 n)
+
+-- | Get @n@ bits as a 'Word16'. @n@ must be within @[0..16]@.
+getWord16 :: Int -> BitGet Word16
+getWord16 n = block (word16 n)
+
+getWord16be :: Int -> BitGet Word16
+getWord16be = getWord16
+{-# DEPRECATED getWord16be "Use 'getWord16' instead" #-}
+
+-- | Get @n@ bits as a 'Word32'. @n@ must be within @[0..32]@.
+getWord32 :: Int -> BitGet Word32
+getWord32 n = block (word32 n)
+
+getWord32be :: Int -> BitGet Word32
+getWord32be = getWord32
+{-# DEPRECATED getWord32be "Use 'getWord32' instead" #-}
+
+-- | Get @n@ bits as a 'Word64'. @n@ must be within @[0..64]@.
+getWord64 :: Int -> BitGet Word64
+getWord64 n = block (word64 n)
+
+getWord64be :: Int -> BitGet Word64
+getWord64be = getWord64
+{-# DEPRECATED getWord64be "Use 'getWord64' instead" #-}
+
+-- | Get @n@ bytes as a 'ByteString'.
+getByteString :: Int -> BitGet ByteString
+getByteString n = block (byteString n)
+
+-- | Get @n@ bytes as a lazy ByteString.
+getLazyByteString :: Int -> BitGet L.ByteString
+getLazyByteString n = do
+  (S _ o bo) <- getState
+  case o of
+    0 -> B $ \s -> do
+            putBackState s
+            lbs <- B.getLazyByteString (fromIntegral n)
+            return (S B.empty 0 bo, lbs)
+    _ -> L.fromChunks . (:[]) <$> Data.Binary.Bits.Get.getByteString n
+
+
+
+
+
+-- | A block that will be read with only one boundary check. Needs to know the
 -- number of bits in advance.
 data Block a = Block Int (S -> a)
 
@@ -176,331 +435,40 @@ block (Block i p) = do
   putState $! (incS i s)
   return $! p s
 
-incS :: Int -> S -> S
-incS o (S bs n) =
-  let !o' = (n+o)
-      !d = o' `shiftR` 3
-      !n' = o' .&. make_mask 3
-  in S (unsafeDrop d bs) n'
-
--- | make_mask 3 = 00000111
-make_mask :: (Bits a, Num a) => Int -> a
-make_mask n = (1 `shiftL` fromIntegral n) - 1
-{-# SPECIALIZE make_mask :: Int -> Int #-}
-{-# SPECIALIZE make_mask :: Int -> Word #-}
-{-# SPECIALIZE make_mask :: Int -> Word8 #-}
-{-# SPECIALIZE make_mask :: Int -> Word16 #-}
-{-# SPECIALIZE make_mask :: Int -> Word32 #-}
-{-# SPECIALIZE make_mask :: Int -> Word64 #-}
-
-bit_offset :: Int -> Int
-bit_offset n = make_mask 3 .&. n
-
-byte_offset :: Int -> Int
-byte_offset n = n `shiftR` 3
-
-readBool :: S -> Bool
-readBool (S bs n) = testBit (unsafeHead bs) (7-n)
-
-{-# INLINE readWord8 #-}
-readWord8 :: Int -> S -> Word8
-readWord8 n (S bs o)
-  -- no bits at all, return 0
-  | n == 0 = 0
-
-  -- all bits are in the same byte
-  -- we just need to shift and mask them right
-  | n <= 8 - o = let w = unsafeHead bs
-                     m = make_mask n
-                     w' = (w `shiftr_w8` (8 - o - n)) .&. m
-                 in w'
-
-  -- the bits are in two different bytes
-  -- make a word16 using both bytes, and then shift and mask
-  | n <= 8 = let w = (fromIntegral (unsafeHead bs) `shiftl_w16` 8) .|.
-                     (fromIntegral (unsafeIndex bs 1))
-                 m = make_mask n
-                 w' = (w `shiftr_w16` (16 - o - n)) .&. m
-             in fromIntegral w'
-
-{-# INLINE readWord16be #-}
-readWord16be :: Int -> S -> Word16
-readWord16be n s@(S bs o)
-
-  -- 8 or fewer bits, use readWord8
-  | n <= 8 = fromIntegral (readWord8 n s)
-
-  -- handle 9 or more bits, stored in two bytes
-
-  -- no offset, plain and simple 16 bytes
-  | o == 0 && n == 16 = let msb = fromIntegral (unsafeHead bs)
-                            lsb = fromIntegral (unsafeIndex bs 1)
-                            w = (msb `shiftl_w16` 8) .|. lsb
-                        in w
-
-  -- no offset, but not full 16 bytes
-  | o == 0 = let msb = fromIntegral (unsafeHead bs)
-                 lsb = fromIntegral (unsafeIndex bs 1)
-                 w = (msb `shiftl_w16` (n-8)) .|. (lsb `shiftr_w16` (16-n))
-             in w
-
-  -- with offset, and n=9-16
-  | n <= 16 = readWithOffset s shiftl_w16 shiftr_w16 n
-
-  | otherwise = error "readWord16be: tried to read more than 16 bits"
-
-{-# INLINE readWord32be #-}
-readWord32be :: Int -> S -> Word32
-readWord32be n s@(S _ o)
-  -- 8 or fewer bits, use readWord8
-  | n <= 8 = fromIntegral (readWord8 n s)
-
-  -- 16 or fewer bits, use readWord16be
-  | n <= 16 = fromIntegral (readWord16be n s)
-
-  | o == 0 = readWithoutOffset s shiftl_w32 shiftr_w32 n
-
-  | n <= 32 = readWithOffset s shiftl_w32 shiftr_w32 n
-
-  | otherwise = error "readWord32be: tried to read more than 32 bits"
-
-
-{-# INLINE readWord64be #-}
-readWord64be :: Int -> S -> Word64
-readWord64be n s@(S _ o)
-  -- 8 or fewer bits, use readWord8
-  | n <= 8 = fromIntegral (readWord8 n s)
-
-  -- 16 or fewer bits, use readWord16be
-  | n <= 16 = fromIntegral (readWord16be n s)
-
-  | o == 0 = readWithoutOffset s shiftl_w64 shiftr_w64 n
-
-  | n <= 64 = readWithOffset s shiftl_w64 shiftr_w64 n
-
-  | otherwise = error "readWord64be: tried to read more than 64 bits"
-
-
-readByteString :: Int -> S -> ByteString
-readByteString n s@(S bs o)
-  -- no offset, easy.
-  | o == 0 = unsafeTake n bs
-  -- offset. ugg. this is really naive and slow. but also pretty easy :)
-  | otherwise = B.pack (P.map (readWord8 8) (P.take n (iterate (incS 8) s)))
-
-readWithoutOffset :: (Bits a, Num a)
-                  => S -> (a -> Int -> a) -> (a -> Int -> a) -> Int -> a
-readWithoutOffset (S bs o) shifterL shifterR n
-  | o /= 0 = error "readWithoutOffset: there is an offset"
-
-  | bit_offset n == 0 && byte_offset n <= 4 = 
-              let segs = byte_offset n
-                  bn 0 = fromIntegral (unsafeHead bs)
-                  bn n = (bn (n-1) `shifterL` 8) .|. fromIntegral (unsafeIndex bs n)
-
-              in bn (segs-1)
-
-  | n <= 64 = let segs = byte_offset n
-                  o' = bit_offset (n - 8 + o)
-
-                  bn 0 = fromIntegral (unsafeHead bs)
-                  bn n = (bn (n-1) `shifterL` 8) .|. fromIntegral (unsafeIndex bs n)
-
-                  msegs = bn (segs-1) `shifterL` o'
-
-                  last = (fromIntegral (unsafeIndex bs segs)) `shifterR` (8 - o')
-
-                  w = msegs .|. last
-              in w
-
-readWithOffset :: (Bits a, Num a)
-         => S -> (a -> Int -> a) -> (a -> Int -> a) -> Int -> a
-readWithOffset (S bs o) shifterL shifterR n
-  | n <= 64 = let bits_in_msb = 8 - o
-                  (n',top) = (n - bits_in_msb
-                             , (fromIntegral (unsafeHead bs) .&. make_mask bits_in_msb) `shifterL` n')
-                    
-                  segs = byte_offset n'
-
-                  bn 0 = 0
-                  bn n = (bn (n-1) `shifterL` 8) .|. fromIntegral (unsafeIndex bs n)
-
-                  o' = bit_offset n'
-
-                  mseg = bn segs `shifterL` o'
-
-                  last | o' > 0 = (fromIntegral (unsafeIndex bs (segs + 1))) `shifterR` (8 - o')
-                       | otherwise = 0
-
-                  w = top .|. mseg .|. last
-              in w
-
-------------------------------------------------------------------------
--- | 'BitGet' is a monad, applicative and a functor. See 'runBitGet'
--- for how to run it.
-newtype BitGet a = B { runState :: S -> Get (S,a) }
-
-instance Monad BitGet where
-  return x = B $ \s -> return (s,x)
-  fail str = B $ \(S inp n) -> putBackState inp n >> fail str
-  (B f) >>= g = B $ \s -> do (s',a) <- f s
-                             runState (g a) s'
-
-instance Functor BitGet where
-  fmap f m = m >>= \a -> return (f a)
-
-instance Applicative BitGet where
-  pure x = return x
-  fm <*> m = fm >>= \f -> m >>= \v -> return (f v)
-
--- | Run a 'BitGet' within the Binary packages 'Get' monad. If a byte has
--- been partially consumed it will be discarded once 'runBitGet' is finished.
-runBitGet :: BitGet a -> Get a
-runBitGet bg = do
-  s <- mkInitState
-  ((S str' n),a) <- runState bg s
-  putBackState str' n
-  return a
-
-mkInitState :: Get S
-mkInitState = do
-  str <- get
-  put B.empty
-  return (S str 0)
-
-putBackState :: B.ByteString -> Int -> Get ()
-putBackState bs n = do
- remaining <- get
- put (B.drop (if n==0 then 0 else 1) bs `B.append` remaining)
-
-getState :: BitGet S
-getState = B $ \s -> return (s,s)
-
-putState :: S -> BitGet ()
-putState s = B $ \_ -> return (s,())
-
--- | Make sure there are at least @n@ bits.
-ensureBits :: Int -> BitGet ()
-ensureBits n = do
-  (S bs o) <- getState
-  if n <= (B.length bs * 8 - o)
-    then return ()
-    else do let currentBits = B.length bs * 8 - o
-            let byteCount = (n - currentBits + 7) `div` 8
-            B $ \_ -> do B.ensureN byteCount
-                         bs' <- B.get
-                         put B.empty
-                         return (S (bs`append`bs') o, ())
-
--- | Get 1 bit as a 'Bool'.
-getBool :: BitGet Bool
-getBool = block bool
-
--- | Get @n@ bits as a 'Word8'. @n@ must be within @[0..8]@.
-getWord8 :: Int -> BitGet Word8
-getWord8 n = block (word8 n)
-
--- | Get @n@ bits as a 'Word16'. @n@ must be within @[0..16]@.
-getWord16be :: Int -> BitGet Word16
-getWord16be n = block (word16be n)
-
--- | Get @n@ bits as a 'Word32'. @n@ must be within @[0..32]@.
-getWord32be :: Int -> BitGet Word32
-getWord32be n = block (word32be n)
-
--- | Get @n@ bits as a 'Word64'. @n@ must be within @[0..64]@.
-getWord64be :: Int -> BitGet Word64
-getWord64be n = block (word64be n)
-
--- | Get @n@ bytes as a 'ByteString'.
-getByteString :: Int -> BitGet ByteString
-getByteString n = block (byteString n)
-
--- | Get @n@ bytes as a lazy ByteString.
-getLazyByteString :: Int -> BitGet L.ByteString
-getLazyByteString n = do
-  (S _ o) <- getState
-  case o of
-    0 -> B $ \ (S bs o') -> do
-            putBackState bs o'
-            lbs <- B.getLazyByteString (fromIntegral n)
-            return (S B.empty 0, lbs)
-    _ -> L.fromChunks . (:[]) <$> Data.Binary.Bits.Get.getByteString n
-
--- | Test whether all input has been consumed, i.e. there are no remaining
--- undecoded bytes.
-isEmpty :: BitGet Bool
-isEmpty = B $ \ (S bs o) -> if B.null bs
-                               then B.isEmpty >>= \e -> return (S bs o, e)
-                               else return (S bs o, False)
-
 -- | Read a 1 bit 'Bool'.
 bool :: Block Bool
 bool = Block 1 readBool
 
 -- | Read @n@ bits as a 'Word8'. @n@ must be within @[0..8]@.
 word8 :: Int -> Block Word8
-word8 n = Block n (readWord8 n)
+word8 n = Block n (readWordChecked 8 n)
 
 -- | Read @n@ bits as a 'Word16'. @n@ must be within @[0..16]@.
+word16 :: Int -> Block Word16
+word16 n = Block n (readWordChecked 16 n)
+
 word16be :: Int -> Block Word16
-word16be n = Block n (readWord16be n)
+word16be = word16
+{-# DEPRECATED word16be "Use 'word16' instead" #-}
 
 -- | Read @n@ bits as a 'Word32'. @n@ must be within @[0..32]@.
+word32 :: Int -> Block Word32
+word32 n = Block n (readWordChecked 32 n)
+
 word32be :: Int -> Block Word32
-word32be n = Block n (readWord32be n)
+word32be = word32
+{-# DEPRECATED word32be "Use 'word32' instead" #-}
 
 -- | Read @n@ bits as a 'Word64'. @n@ must be within @[0..64]@.
+word64 :: Int -> Block Word64
+word64 n = Block n (readWordChecked 64 n)
+
 word64be :: Int -> Block Word64
-word64be n = Block n (readWord64be n)
+word64be = word64
+{-# DEPRECATED word64be "Use 'word64' instead" #-}
 
 -- | Read @n@ bytes as a 'ByteString'.
 byteString :: Int -> Block ByteString
 byteString n | n > 0 = Block (n*8) (readByteString n)
              | otherwise = Block 0 (\_ -> B.empty)
 
-------------------------------------------------------------------------
--- Unchecked shifts, from the package binary
-
-shiftl_w16 :: Word16 -> Int -> Word16
-shiftl_w32 :: Word32 -> Int -> Word32
-shiftl_w64 :: Word64 -> Int -> Word64
-
-#if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
-shiftl_w8  (W8#  w) (I# i) = W8# (w `uncheckedShiftL#`   i)
-shiftl_w16 (W16# w) (I# i) = W16# (w `uncheckedShiftL#`   i)
-shiftl_w32 (W32# w) (I# i) = W32# (w `uncheckedShiftL#`   i)
-
-shiftr_w8  (W8#  w) (I# i) = W8# (w `uncheckedShiftRL#`   i)
-shiftr_w16 (W16# w) (I# i) = W16# (w `uncheckedShiftRL#`  i)
-shiftr_w32 (W32# w) (I# i) = W32# (w `uncheckedShiftRL#`  i)
-
-
-#if WORD_SIZE_IN_BITS < 64
-shiftl_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftL64#`  i)
-shiftr_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftRL64#` i)
-
-#if __GLASGOW_HASKELL__ <= 606
--- Exported by GHC.Word in GHC 6.8 and higher
-foreign import ccall unsafe "stg_uncheckedShiftL64"
-    uncheckedShiftL64#     :: Word64# -> Int# -> Word64#
-foreign import ccall unsafe "stg_uncheckedShiftRL64"
-    uncheckedShiftRL64#     :: Word64# -> Int# -> Word64#
-#endif
-
-#else
-shiftl_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftL#`  i)
-shiftr_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftRL#` i)
-#endif
-
-#else
-shiftl_w8 = shiftL
-shiftl_w16 = shiftL
-shiftl_w32 = shiftL
-shiftl_w64 = shiftL
-
-shiftr_w8 = shiftR
-shiftr_w16 = shiftR
-shiftr_w32 = shiftR
-shiftr_w64 = shiftR
-#endif

--- a/Data/Binary/Bits/Internal.hs
+++ b/Data/Binary/Bits/Internal.hs
@@ -1,0 +1,155 @@
+{-# LANGUAGE RankNTypes, MagicHash, BangPatterns, CPP #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Binary.Bits.Get
+-- Copyright   :  (c) Lennart Kolmodin 2010-2011
+-- License     :  BSD3-style (see LICENSE)
+--
+-- Maintainer  :  kolmodin@gmail.com
+-- Stability   :  experimental
+-- Portability :  portable (should run where the package binary runs)
+
+module Data.Binary.Bits.Internal
+   ( make_mask
+   , mask
+   , bit_offset
+   , byte_offset
+   , reverseBits
+   , FastBits(..)
+   )
+where
+
+import Data.Word
+import Data.Bits
+
+#if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
+import GHC.Base
+import GHC.Word
+#endif
+
+-- | make_mask 3 = 00000111
+make_mask :: (Bits a, Num a) => Int -> a
+make_mask n = (1 `shiftL` fromIntegral n) - 1
+{-# SPECIALIZE make_mask :: Int -> Int #-}
+{-# SPECIALIZE make_mask :: Int -> Word #-}
+{-# SPECIALIZE make_mask :: Int -> Word8 #-}
+{-# SPECIALIZE make_mask :: Int -> Word16 #-}
+{-# SPECIALIZE make_mask :: Int -> Word32 #-}
+{-# SPECIALIZE make_mask :: Int -> Word64 #-}
+
+-- | Keep only the n least-significant bits of the given value
+mask :: (Bits a, Num a) => Int -> a -> a
+mask n v = v .&. make_mask n
+{-# INLINE mask #-}
+
+-- | Compute bit offset (equivalent to x `mod` 8 but faster)
+bit_offset :: Int -> Int
+bit_offset n = make_mask 3 .&. n
+{-# INLINE bit_offset #-}
+
+-- | Compute byte offset (equivalent to x `div` 8 but faster)
+byte_offset :: Int -> Int
+byte_offset n = n `shiftR` 3
+{-# INLINE byte_offset #-}
+
+-- | Reverse the @n@ least important bits of the given value
+reverseBits :: (Num a, FastBits a, Bits a) => Int -> a -> a
+reverseBits n value = rec value n 0
+   where
+      -- rec v i r, where
+      --    v is orginal value shifted
+      --    i is the remaining number of bits
+      --    r is current value
+      rec 0 0 r = r
+      rec 0 i r = r `fastShiftL` i
+      rec v i r = rec (v `fastShiftR` 1) (i-1) ((r `fastShiftL` 1) .|. (v .&. 0x1))
+
+
+---------------------------------------------------------------------
+-- Unchecked shifts, from the "binary" package
+
+-- | Class for types supporting fast bit shifting
+class Bits a => FastBits a where
+   fastShiftR :: a -> Int -> a
+   fastShiftR = shiftR
+
+   fastShiftL :: a -> Int -> a
+   fastShiftL = shiftL
+
+   {-# INLINE fastShift #-}
+   fastShift :: a -> Int -> a
+   fastShift x n
+      | n > 0 = fastShiftL x n
+      | n < 0 = fastShiftR x (negate n)
+      | otherwise = x
+
+instance FastBits Word8 where
+   fastShiftR = shiftr_w8
+   fastShiftL = shiftl_w8
+
+instance FastBits Word16 where
+   fastShiftR = shiftr_w16
+   fastShiftL = shiftl_w16
+
+instance FastBits Word32 where
+   fastShiftR = shiftr_w32
+   fastShiftL = shiftl_w32
+
+instance FastBits Word64 where
+   fastShiftR = shiftr_w64
+   fastShiftL = shiftl_w64
+
+instance FastBits Int
+
+instance FastBits Word
+
+
+shiftl_w8  :: Word8  -> Int -> Word8
+shiftl_w16 :: Word16 -> Int -> Word16
+shiftl_w32 :: Word32 -> Int -> Word32
+shiftl_w64 :: Word64 -> Int -> Word64
+
+shiftr_w8  :: Word8  -> Int -> Word8
+shiftr_w16 :: Word16 -> Int -> Word16
+shiftr_w32 :: Word32 -> Int -> Word32
+shiftr_w64 :: Word64 -> Int -> Word64
+
+#if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
+shiftl_w8  (W8# w)  (I# i) = W8#  (w `uncheckedShiftL#`   i)
+shiftl_w16 (W16# w) (I# i) = W16# (w `uncheckedShiftL#`   i)
+shiftl_w32 (W32# w) (I# i) = W32# (w `uncheckedShiftL#`   i)
+
+shiftr_w8  (W8#  w) (I# i) = W8# (w `uncheckedShiftRL#`   i)
+shiftr_w16 (W16# w) (I# i) = W16# (w `uncheckedShiftRL#`  i)
+shiftr_w32 (W32# w) (I# i) = W32# (w `uncheckedShiftRL#`  i)
+
+
+#if WORD_SIZE_IN_BITS < 64
+shiftl_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftL64#`  i)
+shiftr_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftRL64#` i)
+
+#if __GLASGOW_HASKELL__ <= 606
+-- Exported by GHC.Word in GHC 6.8 and higher
+foreign import ccall unsafe "stg_uncheckedShiftL64"
+    uncheckedShiftL64#     :: Word64# -> Int# -> Word64#
+foreign import ccall unsafe "stg_uncheckedShiftRL64"
+    uncheckedShiftRL64#     :: Word64# -> Int# -> Word64#
+#endif
+
+#else
+shiftl_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftL#`  i)
+shiftr_w64 (W64# w) (I# i) = W64# (w `uncheckedShiftRL#` i)
+#endif
+
+#else
+shiftl_w8  = shiftL
+shiftl_w16 = shiftL
+shiftl_w32 = shiftL
+shiftl_w64 = shiftL
+
+shiftr_w8 = shiftR
+shiftr_w16 = shiftR
+shiftr_w32 = shiftR
+shiftr_w64 = shiftR
+#endif

--- a/Data/Binary/Bits/Put.hs
+++ b/Data/Binary/Bits/Put.hs
@@ -2,6 +2,7 @@
 -- |
 -- Module      :  Data.Binary.Bits.Put
 -- Copyright   :  (c) Lennart Kolmodin 2010-2011
+--                (c) Sylvain Henry 2015
 -- License     :  BSD3-style (see LICENSE)
 --
 -- Maintainer  :  kolmodin@gmail.com
@@ -22,6 +23,9 @@ module Data.Binary.Bits.Put
 
           -- ** Words
           , putWord8
+          , putWord16
+          , putWord32
+          , putWord64
           , putWord16be
           , putWord32be
           , putWord64be
@@ -35,10 +39,15 @@ import qualified Data.Binary.Builder as B
 import Data.Binary.Builder ( Builder )
 import qualified Data.Binary.Put as Put
 import Data.Binary.Put ( Put )
+import Data.Binary.Bits.Internal
+import Data.Binary.Bits.BitOrder
+import Data.Binary.Bits.Alignment
 
-import Data.ByteString
+import Data.ByteString as BS
+import Data.ByteString.Unsafe as BS
 
 import Control.Applicative
+import Control.Monad (when)
 import Data.Bits
 import Data.Monoid
 import Data.Word
@@ -47,113 +56,139 @@ data BitPut a = BitPut { run :: (S -> PairS a) }
 
 data PairS a = PairS a {-# UNPACK #-} !S
 
-data S = S !Builder !Word8 !Int
+data S = S !Builder !Word8 !Int !BitOrder
 
 -- | Put a 1 bit 'Bool'.
 putBool :: Bool -> BitPut ()
 putBool b = putWord8 1 (if b then 0xff else 0x00)
 
--- | make_mask 3 = 00000111
-make_mask :: (Bits a, Num a) => Int -> a
-make_mask n = (1 `shiftL` fromIntegral n) - 1
-{-# SPECIALIZE make_mask :: Int -> Int #-}
-{-# SPECIALIZE make_mask :: Int -> Word #-}
-{-# SPECIALIZE make_mask :: Int -> Word8 #-}
-{-# SPECIALIZE make_mask :: Int -> Word16 #-}
-{-# SPECIALIZE make_mask :: Int -> Word32 #-}
-{-# SPECIALIZE make_mask :: Int -> Word64 #-}
+
+-- | Generic putWord
+putWord :: (Num a, FastBits a, Integral a) => Int -> a -> BitPut ()
+putWord n w = BitPut $ \s -> PairS () (putWordS n w s)
+
+putWordS :: (Num a, FastBits a, Integral a) => Int -> a -> S -> S
+putWordS n w s@(S builder b o bo) = s'
+   where
+      -- number of bits that will be stored in the current byte
+      cn = min (8-o) n
+
+      -- new state
+      s' = case n of
+            0 -> s
+            _ -> putWordS (n-cn) w' (flush (S builder b' (o+cn) bo))
+      
+      -- new current byte
+      b' = shl (selectBits w) .|. b
+
+      -- Word containing the remaining (n-cn) bits to store in its LSB
+      w' = case bo of
+         BB -> w
+         BL -> w `fastShiftR` cn
+         LB -> w `fastShiftR` cn
+         LL -> w
+
+      -- Select bits to store in the current byte.
+      -- Put them in the correct order and return them in the least-significant
+      -- bits of the returned value
+      selectBits :: (Num a, FastBits a, Integral a) => a -> Word8
+      selectBits x = fromIntegral $ case bo of
+         BB ->                  mask cn $ x `fastShiftR` (n-cn)
+         LL -> reverseBits cn $ mask cn $ x `fastShiftR` (n-cn)
+         LB ->                  mask cn x
+         BL -> reverseBits cn $ mask cn x
+
+      -- shift left at the correct position
+      shl :: Word8 -> Word8
+      shl x = case bo of
+         BB -> x `fastShiftL` (8-o-cn)
+         BL -> x `fastShiftL` (8-o-cn)
+         LB -> x `fastShiftL` o
+         LL -> x `fastShiftL` o
+
+      flush s2@(S b2 w2 o2 bo2)
+        | o2 == 8   = S (b2 `mappend` B.singleton w2) 0 0 bo2
+        | otherwise = s2
+
 
 -- | Put the @n@ lower bits of a 'Word8'.
 putWord8 :: Int -> Word8 -> BitPut ()
-putWord8 n w = BitPut $ \s -> PairS () $
-  let w' = make_mask n .&. w in
-  case s of
-                -- a whole word8, no offset
-    (S b t o) | n == 8 && o == 0 -> flush $ S b w n
-                -- less than a word8, will fit in the current word8
-              | n <= 8 - o       -> flush $ S b (t .|. (w' `shiftL` (8 - n - o))) (o+n)
-                -- will finish this word8, and spill into the next one
-              | otherwise -> flush $
-                              let o' = o + n - 8
-                                  b' = t .|. (w' `shiftR` o')
-                                  t' = w `shiftL` (8 - o')
-                              in S (b `mappend` B.singleton b') t' o'
+putWord8 = putWord
 
 -- | Put the @n@ lower bits of a 'Word16'.
+putWord16 :: Int -> Word16 -> BitPut ()
+putWord16 = putWord
+
 putWord16be :: Int -> Word16 -> BitPut ()
-putWord16be n w
-  | n <= 8 = putWord8 n (fromIntegral w)
-  | otherwise =
-      BitPut $ \s -> PairS () $
-        let w' = make_mask n .&. w in
-        case s of
-          -- as n>=9, it's too big to fit into one single byte
-          -- it'll either use 2 or 3 bytes
-                                     -- it'll fit in 2 bytes
-          (S b t o) | o + n <= 16 -> flush $
-                        let o' = o + n - 8
-                            b' = t .|. fromIntegral (w' `shiftR` o')
-                            t' = fromIntegral (w `shiftL` (8-o'))
-                        in (S (b `mappend` B.singleton b') t' o')
-                                   -- 3 bytes required
-                    | otherwise -> flush $
-                        let o'  = o + n - 16
-                            b'  = t .|. fromIntegral (w' `shiftR` (o' + 8))
-                            b'' = fromIntegral ((w `shiftR` o') .&. 0xff)
-                            t'  = fromIntegral (w `shiftL` (8-o'))
-                        in (S (b `mappend` B.singleton b' `mappend` B.singleton b'') t' o')
+putWord16be = putWord
+{-# DEPRECATED putWord16be "Use 'putWord16' instead" #-}
 
 -- | Put the @n@ lower bits of a 'Word32'.
+putWord32 :: Int -> Word32 -> BitPut ()
+putWord32 = putWord
+
 putWord32be :: Int -> Word32 -> BitPut ()
-putWord32be n w
-  | n <= 16 = putWord16be n (fromIntegral w)
-  | otherwise = do
-      putWord32be (n-16) (w`shiftR`16)
-      putWord32be    16  (w .&. 0x0000ffff)
+putWord32be = putWord
+{-# DEPRECATED putWord32be "Use 'putWord32' instead" #-}
 
 -- | Put the @n@ lower bits of a 'Word64'.
+putWord64 :: Int -> Word64 -> BitPut ()
+putWord64 = putWord
+
 putWord64be :: Int -> Word64 -> BitPut ()
-putWord64be n w
-  | n <= 32 = putWord32be n (fromIntegral w)
-  | otherwise = do
-      putWord64be (n-32) (w`shiftR`32)
-      putWord64be    32  (w .&. 0xffffffff)
+putWord64be = putWord
+{-# DEPRECATED putWord64be "Use 'putWord64' instead" #-}
 
 -- | Put a 'ByteString'.
+--
+-- Examples: 3 bits are already written in the current byte
+--    BB: ABCDEFGH IJKLMNOP -> xxxABCDE FGHIJKLM NOPxxxxx
+--    LB: ABCDEFGH IJKLMNOP -> LMNOPxxx DEFGHIJK xxxxxABC
+--    BL: ABCDEFGH IJKLMNOP -> xxxPONML KJIHGFED CBAxxxxx
+--    LL: ABCDEFGH IJKLMNOP -> EDCBAxxx MLKJIHGF xxxxxPON
 putByteString :: ByteString -> BitPut ()
-putByteString bs = do
-  offset <- hasOffset
-  if offset
-    then mapM_ (putWord8 8) (unpack bs) -- naive
-    else joinPut (Put.putByteString bs)
-  where
-    hasOffset = BitPut $ \ s@(S _ _ o) -> PairS (o /= 0) s
+putByteString bs = BitPut $ \s -> PairS () (putByteStringS bs s)
+
+putByteStringS :: ByteString -> S -> S
+putByteStringS bs s
+   | BS.null bs = s
+   | otherwise  = case s of
+      (S builder b 0 BB) -> S (builder `mappend` B.fromByteString bs) b 0 BB
+      (S builder b 0 LB) -> S (builder `mappend` B.fromByteString (BS.reverse bs)) b 0 LB
+      (S builder b 0 LL) -> S (builder `mappend` B.fromByteString (rev bs)) b 0 LL
+      (S builder b 0 BL) -> S (builder `mappend` B.fromByteString (rev (BS.reverse bs))) b 0 BL
+      (S _ _ _ BB)       -> putByteStringS (BS.unsafeTail bs) (putWordS 8 (BS.unsafeHead bs) s)
+      (S _ _ _ LB)       -> putByteStringS (BS.unsafeInit bs) (putWordS 8 (BS.unsafeLast bs) s)
+      (S _ _ _ BL)       -> putByteStringS (BS.unsafeInit bs) (putWordS 8 (BS.unsafeLast bs) s)
+      (S _ _ _ LL)       -> putByteStringS (BS.unsafeTail bs) (putWordS 8 (BS.unsafeHead bs) s)
+   where
+      rev    = BS.map (reverseBits 8)
+
 
 -- | Run a 'Put' inside 'BitPut'. Any partially written bytes will be flushed
 -- before 'Put' executes to ensure byte alignment.
+--
+-- Warning: this method does not take bit order into account (i.e. BB assumed)
 joinPut :: Put -> BitPut ()
 joinPut m = BitPut $ \s0 -> PairS () $
-  let (S b0 _ _) = flushIncomplete s0
+  let (S b0 _ _ bo) = flushIncomplete s0
       b = Put.execPut m
-  in (S (b0`mappend`b) 0 0)
-
-flush :: S -> S
-flush s@(S b w o)
-  | o > 8 = error "flush: offset > 8"
-  | o == 8 = S (b `mappend` B.singleton w) 0 0
-  | otherwise = s
+  in (S (b0`mappend`b) 0 0 bo)
 
 flushIncomplete :: S -> S
-flushIncomplete s@(S b w o)
+flushIncomplete s@(S b w o bo)
   | o == 0 = s
-  | otherwise = (S (b `mappend` B.singleton w) 0 0)
+  | otherwise = (S (b `mappend` B.singleton w) 0 0 bo)
+
+getOffset :: BitPut Int
+getOffset = BitPut $ \s@(S _ _ o _) -> PairS o s
 
 -- | Run the 'BitPut' monad inside 'Put'.
 runBitPut :: BitPut () -> Put.Put
 runBitPut m = Put.putBuilder b
   where
-  PairS _ s = run m (S mempty 0 0)
-  (S b _ _) = flushIncomplete s
+  PairS _ s   = run m (S mempty 0 0 BB)
+  (S b _ _ _) = flushIncomplete s
 
 instance Functor BitPut where
   fmap f (BitPut k) = BitPut $ \s ->
@@ -173,3 +208,20 @@ instance Monad BitPut where
         PairS b s'' = run (k a) s'
     in PairS b s''
   return x = BitPut $ \s -> PairS x s
+
+instance BitOrderable BitPut where
+   setBitOrder bo = BitPut $ \(S bu b o _) -> PairS () (S bu b o bo)
+
+   getBitOrder = BitPut $ \s@(S _ _ _ bo) -> PairS bo s
+
+instance Alignable BitPut where
+   -- | Skip the given number of bits
+   skipBits n
+      | n <= 64   = putWord64 n 0
+      | otherwise = putWord64 64 0 >> skipBits (n-64)
+
+   -- | Skip bits if necessary to align to the next byte
+   alignByte = do
+      o <- getOffset
+      when (o /= 0) $
+         skipBits (8-o)

--- a/binary-bits.cabal
+++ b/binary-bits.cabal
@@ -1,6 +1,6 @@
 -- http://www.haskell.org/cabal/release/cabal-latest/doc/users-guide/
 name:                binary-bits
-version:             0.5
+version:             0.6
 synopsis:            Bit parsing/writing on top of binary.
 description:         Bit parsing/writing on top of binary. Provides functions to
                      read and write bits to and from 8\/16\/32\/64 words.
@@ -24,7 +24,10 @@ library
 
   exposed-modules:     Data.Binary.Bits ,
                        Data.Binary.Bits.Put ,
-                       Data.Binary.Bits.Get
+                       Data.Binary.Bits.Get ,
+                       Data.Binary.Bits.BitOrder ,
+                       Data.Binary.Bits.Alignment
+  other-modules:       Data.Binary.Bits.Internal
 
   default-language:    Haskell98
 
@@ -34,6 +37,7 @@ test-suite qc
   type: exitcode-stdio-1.0
   main-is: BitsQC.hs
   default-language:    Haskell98
+  --ghc-options: -O2 -Wall
 
   build-depends: base==4.*, binary >= 0.6.0.0, bytestring,
                  QuickCheck>=2, random,


### PR DESCRIPTION
Bit ordering: this package now supports writing bits in different
orders. You can indicate if bytes are filled from MSB to LSB (the mode
we had until now) or vice-versa, and you can indicate if words you write
are stored with the MSB first (what we had until now) or with the LSB
first.

Bit skipping: you can now skip a given amount of bits in BitGet and
BitPut. In the latter, bits written are considered undefined (currently
we write zeroes but you shouldn't rely on this).

Byte alignment: you can now skip an undetermined number of bits in
BitGet and BitPut to align the cursor on the next byte. If the cursor is
already on a byte boundary, the cursor doesn't move.

MSB: most-significant bit(s)
LSB: least-significant bit(s)
